### PR TITLE
Add support for .NETStandard 2.0

### DIFF
--- a/src/PCEHR.Sample/PCEHR.Sample.csproj
+++ b/src/PCEHR.Sample/PCEHR.Sample.csproj
@@ -1,47 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{65CFECFD-F1CE-4967-AD3E-53C78777B08F}</ProjectGuid>
+    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>PCEHR.Sample</RootNamespace>
-    <AssemblyName>PCEHR.Sample</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <StartupObject>
-    </StartupObject>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <TargetFrameworkProfile />
+    <StartupObject></StartupObject>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Nehta.VendorLibrary.Common, Version=4.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nehta.VendorLibrary.Common.4.2.1\lib\net40\Nehta.VendorLibrary.Common.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+	
+  <!-- Conditionally obtain references for the .NET40 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -61,43 +27,16 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+
+  <!-- Conditionally obtain references for the .NETStandard2.0 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+	<PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0" />
+  </ItemGroup>
+	
   <ItemGroup>
-    <Compile Include="DocumentRegisterClientSample.cs" />
-    <Compile Include="GainPCEHRAccessClientSample.cs" />
-    <Compile Include="DoesPCEHRExistClientSample.cs" />
-    <Compile Include="GetAuditViewClientSample.cs" />
-    <Compile Include="GetChangeHistoryViewClientSample.cs" />
-    <Compile Include="GetDocumentClientSample.cs" />
-    <Compile Include="GetDocumentListClientSample.cs" />
-    <Compile Include="GetIndividualDetailsViewClientSample.cs" />
-    <Compile Include="GetRepresentativeListClientSample.cs" />
-    <Compile Include="GetTemplateClientSample.cs" />
-    <Compile Include="GetViewClientSample.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="PcehrHeaderHelper.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RegisterPCEHRClientSample.cs" />
-    <Compile Include="RemoveDocumentClientSample.cs" />
-    <Compile Include="SearchTemplateClientSample.cs" />
-    <Compile Include="UploadDocumentClientSample.cs" />
-    <Compile Include="UploadDocumentMetadataClientSample.cs" />
+    <ProjectReference Include="..\PCEHR\PCEHR.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\PCEHR\PCEHR.csproj">
-      <Project>{DC5F3E39-5D6D-4EA1-8032-CBF6EB0D7A3D}</Project>
-      <Name>PCEHR</Name>
-    </ProjectReference>
+	  <ProjectReference Include="..\..\..\nehta-common-dotnet\src\Common\Common.csproj" /><!--Change to Nuget package version-->
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/PCEHR/Helper/PCEHREndpointProcessor.cs
+++ b/src/PCEHR/Helper/PCEHREndpointProcessor.cs
@@ -53,7 +53,11 @@ namespace Nehta.VendorLibrary.PCEHR
             InspectorBehavior newBehavior = new InspectorBehavior(soapMessages, signingCertificate);
 
             // Add the behavior
+#if NET40
             endpoint.Behaviors.Add(newBehavior);
+#else
+            endpoint.EndpointBehaviors.Add(newBehavior);
+#endif
         }
 
         /// <summary>
@@ -247,7 +251,11 @@ namespace Nehta.VendorLibrary.PCEHR
 
             public void ApplyClientBehavior(ServiceEndpoint endpoint, System.ServiceModel.Dispatcher.ClientRuntime clientRuntime)
             {
+#if NET40
                 clientRuntime.MessageInspectors.Add(new MessageInspector(soapMessages, signingCertificate));
+#else
+                clientRuntime.ClientMessageInspectors.Add(new MessageInspector(soapMessages, signingCertificate));
+#endif
             }
 
             public void ApplyDispatchBehavior(ServiceEndpoint endpoint, System.ServiceModel.Dispatcher.EndpointDispatcher endpointDispatcher)

--- a/src/PCEHR/PCEHR.csproj
+++ b/src/PCEHR/PCEHR.csproj
@@ -1,170 +1,51 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{DC5F3E39-5D6D-4EA1-8032-CBF6EB0D7A3D}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Nehta.VendorLibrary.MHR</RootNamespace>
-    <AssemblyName>Nehta.VendorLibrary.MHR</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nehta.VendorLibrary.Common, Version=4.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nehta.VendorLibrary.Common.4.2.1\lib\net40\Nehta.VendorLibrary.Common.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization">
-      <RequiredTargetFramework>3.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Security" />
-    <Reference Include="System.ServiceModel">
-      <RequiredTargetFramework>3.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Web" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Enums\ServiceRequestorOption.cs" />
-    <Compile Include="GeneratorCode\PCEHR_AdvanceCarePlanningView.cs" />
-    <Compile Include="GeneratorCode\PCEHR_AdvanceCarePlanningView_Response.cs" />
-    <Compile Include="GeneratorCode\PCEHR_DiagnosticImagingReportView.cs" />
-    <Compile Include="GeneratorCode\PCEHR_DiagnosticImagingReportView_Response.cs" />
-    <Compile Include="GeneratorCode\PCEHR_DocumentRegistry11.cs" />
-    <Compile Include="GeneratorCode\PCEHR_DocumentRepository11.cs" />
-    <Compile Include="GeneratorCode\PCEHR_GetAuditView11.cs" />
-    <Compile Include="GeneratorCode\PCEHR_GetChangeHistoryView11.cs" />
-    <Compile Include="GeneratorCode\PCEHR_GetIndividualDetailsView20.cs" />
-    <Compile Include="GeneratorCode\PCEHR_GetRepresentativeList11.cs" />
-    <Compile Include="GeneratorCode\PCEHR_GetTemplate11.cs" />
-    <Compile Include="GeneratorCode\PCEHR_GetView10.cs" />
-    <Compile Include="GeneratorCode\PCEHR_HealthCheckScheduleView.cs" />
-    <Compile Include="GeneratorCode\PCEHR_HealthRecordOverview.cs" />
-    <Compile Include="GeneratorCode\PCEHR_HealthRecordOverview_Response.cs" />
-    <Compile Include="GeneratorCode\PCEHR_MedicareOverview.cs" />
-    <Compile Include="GeneratorCode\PCEHR_ObservationView.cs" />
-    <Compile Include="GeneratorCode\PCEHR_PathologyReportView.cs" />
-    <Compile Include="GeneratorCode\PCEHR_PathologyReportView_Response.cs" />
-    <Compile Include="GeneratorCode\PCEHR_PCEHRProfile11.cs" />
-    <Compile Include="GeneratorCode\PCEHR_PrescriptionAndDispenseView.cs" />
-    <Compile Include="GeneratorCode\PCEHR_RegisterPCEHR20.cs" />
-    <Compile Include="GeneratorCode\PCEHR_RemoveDocument11.cs" />
-    <Compile Include="GeneratorCode\PCEHR_SearchTemplate11.cs" />
-    <Compile Include="GetIndividualDetailsViewClient.cs" />
-    <Compile Include="GetRepresentativeListClient.cs" />
-    <Compile Include="GetViewClient.cs" />
-    <Compile Include="Helper\CommonPcehrHeader.cs" />
-    <Compile Include="Helper\MHR_Document_Register.cs" />
-    <Compile Include="Helper\SoapMessages.cs" />
-    <Compile Include="Helper\SoapSignatureUtility.cs" />
-    <Compile Include="Helper\XdsMetadataHelper.cs" />
-    <Compile Include="Helper\PCEHRHeaderValidator.cs" />
-    <Compile Include="GeneratorCodeModifications\PCEHR_GetView10.cs" />
-    <Compile Include="Helper\XdsRecord.cs" />
-    <Compile Include="IDoesPCEHRExistClient.cs" />
-    <Compile Include="IGainPCEHRAccessClient.cs" />
-    <Compile Include="IGetAuditViewClient.cs" />
-    <Compile Include="IGetChangeHistoryViewClient.cs" />
-    <Compile Include="IGetDocumentClient.cs" />
-    <Compile Include="IGetDocumentListClient.cs" />
-    <Compile Include="IGetIndividualDetailsViewClient.cs" />
-    <Compile Include="IGetRepresentativeListClient.cs" />
-    <Compile Include="IGetTemplateClient.cs" />
-    <Compile Include="IGetViewClient.cs" />
-    <Compile Include="IRegisterPCEHRClient.cs" />
-    <Compile Include="IRemoveDocumentClient.cs" />
-    <Compile Include="ISearchTemplateClient.cs" />
-    <Compile Include="ISoapClient.cs" />
-    <Compile Include="IUploadDocumentClient.cs" />
-    <Compile Include="IUploadDocumentMetadataClient.cs" />
-    <Compile Include="RegisterPCEHRClient.cs" />
-    <Compile Include="SearchTemplateClient.cs" />
-    <Compile Include="GetTemplateClient.cs" />
-    <Compile Include="GetAuditViewClient.cs" />
-    <Compile Include="Enums\ClassCodes.cs" />
-    <Compile Include="Enums\HealthcareFacilityTypeCodes.cs" />
-    <Compile Include="Enums\PracticeSettingTypes.cs" />
-    <Compile Include="GetChangeHistoryViewClient.cs" />
-    <Compile Include="GetDocumentClient.cs" />
-    <Compile Include="Query\Author.cs" />
-    <Compile Include="Helper\BindingHelper.cs" />
-    <Compile Include="Enums\DocumentStatus.cs" />
-    <Compile Include="Helper\CodedValueAttribute.cs" />
-    <Compile Include="Helper\XdsMetadata.cs" />
-    <Compile Include="Query\ISO8601DateTime.cs" />
-    <Compile Include="Query\AdhocQueryBuilder.cs" />
-    <Compile Include="RemoveDocumentClient.cs" />
-    <Compile Include="UploadDocumentClient.cs" />
-    <Compile Include="UploadDocumentMetadataClient.cs" />
-    <Compile Include="DocumentRegistryClient.cs" />
-    <Compile Include="DoesPCEHRExistClient.cs" />
-    <Compile Include="GainPCEHRAccessClient.cs" />
-    <Compile Include="DocumentRepositoryClient.cs" />
-    <Compile Include="GetDocumentListClient.cs" />
-    <Compile Include="PCEHRProfileClient.cs" />
-    <Compile Include="Helper\PCEHREndpointProcessor.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Nehta.VendorLibrary.MHR</RootNamespace>
+		<AssemblyName>Nehta.VendorLibrary.MHR</AssemblyName>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<UseWindowsForms>true</UseWindowsForms>
+		<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+	</PropertyGroup>
+	
+	<!-- Conditionally obtain references for the .NET40 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+		<Reference Include="System" />
+		<Reference Include="System.Core">
+			<RequiredTargetFramework>3.5</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Drawing" />
+		<Reference Include="System.Numerics" />
+		<Reference Include="System.Runtime.Serialization">
+			<RequiredTargetFramework>3.0</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Security" />
+		<Reference Include="System.ServiceModel">
+			<RequiredTargetFramework>3.0</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Web" />
+		<Reference Include="System.Windows.Forms" />
+		<Reference Include="System.Xml.Linq">
+			<RequiredTargetFramework>3.5</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Data.DataSetExtensions">
+			<RequiredTargetFramework>3.5</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="System.Data" />
+		<Reference Include="System.Xml" />
+	</ItemGroup>
+	
+	<!-- Conditionally obtain references for the .NETStandard2.0 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageReference Include="System.ServiceModel.Http" Version="4.9.0"/>
+		<PackageReference Include="System.ServiceModel.Primitives" Version="4.9.0"/>
+	</ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="DotNetZip" Version="1.11.0"/>
+		<ProjectReference Include="..\..\..\nehta-common-dotnet\src\Common\Common.csproj" /><!--Change to Nuget package version-->
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+	</ItemGroup>
+	<PropertyGroup/>
 </Project>


### PR DESCRIPTION
Depends on https://github.com/AuDigitalHealth/nehta-common-dotnet/pull/2

TO DO
Change `<ProjectReference Include="..\..\..\nehta-common-dotnet\src\Common\Common.csproj" /><!--Change to Nuget package version-->` to the Nuget package version

Problem statement
Currently the HIS and MHR libraries only work on .NET Full Framework. Microsoft have stopped developing .NET Full Framework and .NET Core (now called .NET 5 and .NET 6) is the future https://devblogs.microsoft.com/dotnet/net-core-is-the-future-of-net/

This PR adds support for .NET Standard 2.0
.NET Standard is Microsoft's recommended approach for library developers as it allows your library to run on the greatest range of workloads: .NET Full Framework, .NET Core and .NET 5 & 6
https://docs.microsoft.com/en-us/dotnet/standard/class-libraries and https://docs.microsoft.com/en-us/dotnet/standard/net-standard

I've gone with the multi targeting approach https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting as I wasn't sure if you still need to be able to use .NET Framework 4.0. I'd seriously consider only supporting .NET Standard as these old versions of full framework are no longer supported by Microsoft

### Definition of Done

* [ ] Code has been peer reviewed
* [ ] Test coverage has been maintained or improved
* [ ] All tests pass within CI
* [ ] README is up to date

